### PR TITLE
Bump google-protobuf dev lock to 4.35.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,22 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    bigdecimal (3.1.8)
+    bigdecimal (4.1.2)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    google-protobuf (4.28.0)
+    google-protobuf (4.35.1)
       bigdecimal
-      rake (>= 13)
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
     io-console (0.7.2)
     irb (1.14.1)
       rdoc (>= 4.0.0)
@@ -30,7 +39,7 @@ GEM
       stringio
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.4.2)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -56,8 +65,10 @@ GEM
     yard (0.9.37)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-23
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   debug


### PR DESCRIPTION
Bumps the dev lockfile to google-protobuf 4.35.1 (from 4.28.0). Pulls the transitive bumps it requires: rake 13.4.2 (`~> 13.3` now) and bigdecimal 4.1.2. Adds `x86_64-linux`/`aarch64-linux` platforms so CI resolves precompiled gems.

`bin/rake` green on 4.35.1: 80 runs, 208 assertions, 0 failures; rubocop clean.
